### PR TITLE
Entries limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://aws.amazon.com/about-aws/whats-new/2023/09/amazon-route-53-managed-prefi
 
 The CloudFormation template `cloudformation/template.yml` creates a stack with the following resources:
 
-1. AWS Lambda function with customizable config file called `services.json`. The function's code is in `lambda/update_aws_ip_ranges.py` and is written in Python compatible with version 3.10.
+1. AWS Lambda function with customizable config file called `services.json`. The function's code is in `lambda/update_aws_ip_ranges.py` and is written in Python compatible with version 3.12.
 1. Lambda function's execution role.
 1. SNS subscription and Lambda invocation permissions for the `arn:aws:sns:us-east-1:806199016981:AmazonIpSpaceChanged` SNS topic.
 

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -29,7 +29,7 @@ Resources:
       Handler: 'update_aws_ip_ranges.lambda_handler'
       MemorySize: 256
       Role: !GetAtt 'LambdaUpdateIPRangesIamRole.Arn'
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 300
       ReservedConcurrentExecutions: 2
       Code:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -275,7 +275,7 @@ resource "aws_lambda_function" "update_ip_ranges" {
   description                    = "This Lambda function, invoked by an incoming SNS message, updates the IPv4 and IPv6 ranges with the addresses from the specified services"
   role                           = aws_iam_role.update_ip_ranges.arn
   handler                        = "update_aws_ip_ranges.lambda_handler"
-  runtime                        = "python3.11"
+  runtime                        = "python3.12"
   timeout                        = 300
   reserved_concurrent_executions = 2
   memory_size                    = 256


### PR DESCRIPTION
*Description of changes:*
When a prefix list has more than 100 entries, code would fail because API call doesn't allow entries with more than 100 objects in one call.

When there are more than 100 entries, it will split in several API calls.

Also upgrade Python version to 3.12.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
